### PR TITLE
Fix foooter URLs

### DIFF
--- a/frontend/src/components/footer.vue
+++ b/frontend/src/components/footer.vue
@@ -11,8 +11,8 @@
     <a href="/backend/schema" target="_blank" data-microtip-position="top" role="tooltip" aria-label="API Schema"><span class="icon is-large"><i class="material-icons">api</i></span></a>
     <a href="https://wiki.savageaim.com" target="_blank" data-microtip-position="top" role="tooltip" aria-label="Wiki"><span class="icon is-large"><i class="material-icons">menu_book</i></span></a>
     <a data-microtip-position="top" role="tooltip" aria-label="Changelog" @click="showChangelog"><span class="icon is-large"><i class="material-icons">update</i></span></a>
-    <a href="https://github.com/Savage-Aim/app" target="_blank" data-microtip-position="top" role="tooltip" aria-label="Github Repo"><span class="icon is-large"><i class="material-icons">code</i></span></a>
-    <a href="https://github.com/Savage-Aim/plugin" target="_blank" data-microtip-position="top" role="tooltip" aria-label="Dalamud Plugin"><span class="icon is-large"><i class="material-icons">extension</i></span></a>
+    <a href="https://github.com/SavageAim/app" target="_blank" data-microtip-position="top" role="tooltip" aria-label="Github Repo"><span class="icon is-large"><i class="material-icons">code</i></span></a>
+    <a href="https://github.com/SavageAim/plugin" target="_blank" data-microtip-position="top" role="tooltip" aria-label="Dalamud Plugin"><span class="icon is-large"><i class="material-icons">extension</i></span></a>
     <a class="discord-link" href="https://discord.gg/k8szJ5qAKw" target="_blank" data-microtip-position="top" role="tooltip" aria-label="Savage Aim Discord"><span class="icon is-large"><img src="/discord.svg" alt="Discord Logo" class="image is-24x24 discord" height="24" width="24" /></span></a>
     <p>Savage Aim release {{ $store.state.version }}, by Eira Erikawa (Lich)</p>
     <p>FINAL FANTASY XIV ©2010 - {{ currentYear }} SQUARE ENIX CO., LTD. All Rights Reserved.</p>


### PR DESCRIPTION
The footer urls had `Savage-Aim` instead of `SavageAim` in the links, making them a biiiit hard to use. This fix should correct that.